### PR TITLE
Downgrade to netstandard2.0

### DIFF
--- a/iSHARE/AccessToken/Responses/AccessTokenResponse.cs
+++ b/iSHARE/AccessToken/Responses/AccessTokenResponse.cs
@@ -21,7 +21,7 @@ namespace iSHARE.AccessToken.Responses
 
         public static async Task<AccessTokenResponse> FromHttpContentAsync(HttpContent httpContent)
         {
-            await using var responseStream = await httpContent.ReadAsStreamAsync();
+            using var responseStream = await httpContent.ReadAsStreamAsync();
             return await JsonSerializer.DeserializeAsync<AccessTokenResponse>(responseStream);
         }
     }

--- a/iSHARE/Internals/GenericHttpClient/TokenResponseClient.cs
+++ b/iSHARE/Internals/GenericHttpClient/TokenResponseClient.cs
@@ -49,7 +49,7 @@ namespace iSHARE.Internals.GenericHttpClient
 
         private static async Task<string> ExtractToken(HttpContent httpContent, CancellationToken token)
         {
-            await using var responseStream = await httpContent.ReadAsStreamAsync();
+            using var responseStream = await httpContent.ReadAsStreamAsync();
             var response = await JsonSerializer.DeserializeAsync<Dictionary<string, string>>(
                 responseStream,
                 cancellationToken: token);

--- a/iSHARE/TokenConvert.cs
+++ b/iSHARE/TokenConvert.cs
@@ -43,7 +43,7 @@ namespace iSHARE
 
         private static string BuildArrayString<T>(Claim[] claims)
         {
-            return $"[{string.Join(',', claims.Select(x => x.Value))}]";
+            return $"[{string.Join(",", claims.Select(x => x.Value))}]";
         }
 
         private static void ValidateArguments(JwtSecurityToken jwtToken, string claimName)

--- a/iSHARE/TokenValidator/CertificateUtilities.cs
+++ b/iSHARE/TokenValidator/CertificateUtilities.cs
@@ -45,7 +45,7 @@ namespace iSHARE.TokenValidator
             using var hasher = new SHA256Managed();
             var hashBytes = hasher.ComputeHash(cert.RawData);
 
-            return BitConverter.ToString(hashBytes).Replace("-", "", StringComparison.CurrentCultureIgnoreCase);
+            return BitConverter.ToString(hashBytes).Replace("-", "");
         }
     }
 }

--- a/iSHARE/iSHARE.csproj
+++ b/iSHARE/iSHARE.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>annotations</Nullable>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.6.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The iSHARE library requires `netcoreapp3.1` which is not compatible with the .NET Framework (non-core). By downgrading to `netstandard2.0` a much wider compatibility range can be achieved.

The code changes are minimal and have negligible impact on the library.

If you accept this pull request, it would be nice to push a new NuGet package.